### PR TITLE
Fix compilation error, warnings and migrate to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name        = "psp2-sys"
 version     = "0.2.2"
 authors     = ["Martin Larralde <martin.larralde@ens-cachan.fr>"]
+edition     = "2018"
 license     = "MIT"
 description = "Unsafe Rust FFI bindings to the psp2 headers"
 repository  = "https://github.com/vita-rust/psp2-sys"
@@ -25,4 +26,3 @@ maintenance = { status = "actively-developed" }
 default = []
 unsafe = []
 dox = []
-

--- a/examples/hello_rust_world/Cargo.toml
+++ b/examples/hello_rust_world/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bare_metal_rust"
 version = "0.1.0"
 authors = ["Martin Larralde <martin.larralde@ens-cachan.fr>"]
+edition = "2018"
 
 [lib]
 crate-type = ["staticlib"]

--- a/examples/hello_rust_world/src/debug/screen.rs
+++ b/examples/hello_rust_world/src/debug/screen.rs
@@ -136,7 +136,7 @@ impl<'a> DebugScreen<'a> {
                 continue;
             }
 
-            let mut vram = &mut self.base[self.coord_x + self.coord_y * SCREEN_FB_WIDTH..];
+            let vram = &mut self.base[self.coord_x + self.coord_y * SCREEN_FB_WIDTH..];
             let mut font =
                 &DEBUG_FONT.glyphs[(chr - DEBUG_FONT.first) as usize * bytes_per_glyph..];
             let mut mask = 1 << 7;

--- a/examples/hello_rust_world/src/debug/screen.rs
+++ b/examples/hello_rust_world/src/debug/screen.rs
@@ -3,17 +3,17 @@ use core::fmt::Write;
 use core::mem::size_of;
 use core::slice::from_raw_parts_mut;
 
-use psp2::display::sceDisplaySetFrameBuf;
-use psp2::display::SceDisplayFrameBuf;
-use psp2::display::SceDisplaySetBufSync::SCE_DISPLAY_SETBUF_NEXTFRAME;
-use psp2::kernel::sysmem::sceKernelAllocMemBlock;
-use psp2::kernel::sysmem::sceKernelGetMemBlockBase;
-use psp2::kernel::sysmem::SceKernelMemBlockType::SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW;
-use psp2::kernel::threadmgr::sceKernelCreateMutex;
-use psp2::kernel::threadmgr::sceKernelLockMutex;
-use psp2::kernel::threadmgr::sceKernelUnlockMutex;
-use psp2::types::SceUID;
-use psp2::void;
+use crate::psp2::display::sceDisplaySetFrameBuf;
+use crate::psp2::display::SceDisplayFrameBuf;
+use crate::psp2::display::SceDisplaySetBufSync::SCE_DISPLAY_SETBUF_NEXTFRAME;
+use crate::psp2::kernel::sysmem::sceKernelAllocMemBlock;
+use crate::psp2::kernel::sysmem::sceKernelGetMemBlockBase;
+use crate::psp2::kernel::sysmem::SceKernelMemBlockType::SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW;
+use crate::psp2::kernel::threadmgr::sceKernelCreateMutex;
+use crate::psp2::kernel::threadmgr::sceKernelLockMutex;
+use crate::psp2::kernel::threadmgr::sceKernelUnlockMutex;
+use crate::psp2::types::SceUID;
+use crate::psp2::void;
 
 use super::font::DEBUG_FONT;
 

--- a/examples/hello_rust_world/src/lib.rs
+++ b/examples/hello_rust_world/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, unused_imports, unused_variables, unused_macros, unused_parens)]
-#![feature(lang_items, core_intrinsics, panic_handler, start, used, const_fn)]
+#![feature(lang_items, core_intrinsics, start)]
 #![no_std]
 
 extern crate psp2_sys as psp2;
@@ -17,15 +17,15 @@ pub extern "C" fn eh_personality() {}
 #[panic_handler]
 #[no_mangle]
 fn panic(_info: &PanicInfo) -> ! {
-    unsafe { intrinsics::abort() }
+    intrinsics::abort()
 }
 
 #[no_mangle]
 pub unsafe fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let mut screen = debug::screen::DebugScreen::new();
-    write!(screen, "This bare-metal is starting to rust!\n");
+    write!(screen, "This bare-metal is starting to rust!\n").ok();
     psp2::kernel::threadmgr::sceKernelDelayThread(1 * 1000000); // Wait for 1 second
-    write!(screen, "See ? I told you !\n");
+    write!(screen, "See ? I told you !\n").ok();
     psp2::kernel::threadmgr::sceKernelDelayThread(3 * 1000000);
     psp2::kernel::processmgr::sceKernelExitProcess(0);
     return 0;

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -3,7 +3,7 @@ use crate::types::SceUInt;
 use crate::types::SceUInt64;
 use crate::types::SceUInt8;
 
-#[repr(C)]
+#[repr(u32)]
 pub enum SceCtrlErrorCode {
     SCE_CTRL_ERROR_INVALID_ARG = 0x80340001,
     SCE_CTRL_ERROR_PRIV_REQUIRED = 0x80340002,

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -1,8 +1,3 @@
-use crate::types::SceUChar8;
-use crate::types::SceUInt;
-use crate::types::SceUInt64;
-use crate::types::SceUInt8;
-
 #[repr(u32)]
 pub enum SceCtrlErrorCode {
     SCE_CTRL_ERROR_INVALID_ARG = 0x80340001,

--- a/src/dialog/common.rs
+++ b/src/dialog/common.rs
@@ -1,12 +1,12 @@
-use graphics::gxm::SceGxmColorFormat;
-use graphics::gxm::SceGxmColorSurfaceType;
-use graphics::gxm::SceGxmSyncObject;
-use system_param::SceSystemParamEnterButtonAssign;
-use system_param::SceSystemParamLang;
-use types::SceInt32;
-use types::ScePVoid;
-use types::SceUInt32;
-use types::SceUInt8;
+use crate::graphics::gxm::SceGxmColorFormat;
+use crate::graphics::gxm::SceGxmColorSurfaceType;
+use crate::graphics::gxm::SceGxmSyncObject;
+use crate::system_param::SceSystemParamEnterButtonAssign;
+use crate::system_param::SceSystemParamLang;
+use crate::types::SceInt32;
+use crate::types::ScePVoid;
+use crate::types::SceUInt32;
+use crate::types::SceUInt8;
 
 #[repr(u32)]
 pub enum SceCommonDialogErrorCode {

--- a/src/dialog/message.rs
+++ b/src/dialog/message.rs
@@ -1,6 +1,6 @@
-use types::SceChar8;
-use types::SceInt32;
-use types::SceUInt32;
+use crate::types::SceChar8;
+use crate::types::SceInt32;
+use crate::types::SceUInt32;
 
 use super::common::SceCommonDialogParam;
 use super::common::SceCommonDialogStatus;

--- a/src/dialog/message.rs
+++ b/src/dialog/message.rs
@@ -5,7 +5,7 @@ use types::SceUInt32;
 use super::common::SceCommonDialogParam;
 use super::common::SceCommonDialogStatus;
 
-#[repr(C)]
+#[repr(u32)]
 pub enum SceMsgDialogErrorCode {
     SCE_MSG_DIALOG_ERROR_PARAM = 0x80100A01, // Illegal parameter
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
-use types::SceSize;
-use types::SceUID;
+use crate::types::SceSize;
+use crate::types::SceUID;
 
 #[repr(u32)]
 pub enum SceDisplayErrorCode {
@@ -29,12 +29,12 @@ pub enum SceDisplaySetBufSync {
 
 #[repr(C)]
 pub struct SceDisplayFrameBuf {
-    pub size: SceSize,     //  sizeof(SceDisplayFrameBuf)
-    pub base: *mut ::void, //  Pointer to framebuffer
-    pub pitch: u32,        //  pitch pixels
-    pub pixelformat: u32,  //  pixel format (one of ::SceDisplayPixelFormat)
-    pub width: u32,        //  framebuffer width
-    pub height: u32,       //  framebuffer height
+    pub size: SceSize,          //  sizeof(SceDisplayFrameBuf)
+    pub base: *mut crate::void, //  Pointer to framebuffer
+    pub pitch: u32,             //  pitch pixels
+    pub pixelformat: u32,       //  pixel format (one of ::SceDisplayPixelFormat)
+    pub width: u32,             //  framebuffer width
+    pub height: u32,            //  framebuffer height
 }
 
 #[cfg_attr(

--- a/src/io/devctl.rs
+++ b/src/io/devctl.rs
@@ -1,13 +1,13 @@
-use types::SceOff;
-use types::SceSize;
-use types::SceUID;
+use crate::types::SceOff;
+use crate::types::SceSize;
+use crate::types::SceUID;
 
 #[repr(C)]
 pub struct SceIoDevInfo {
     pub max_size: SceOff,
     pub free_size: SceOff,
     pub cluster_size: SceSize,
-    pub unk: *mut ::void,
+    pub unk: *mut crate::void,
 }
 
 #[cfg_attr(
@@ -18,25 +18,25 @@ extern "C" {
     pub fn sceIoDevctl(
         dev: *const u8,
         cmd: u32,
-        indata: *mut ::void,
+        indata: *mut crate::void,
         inlen: i32,
-        outdata: *mut ::void,
+        outdata: *mut crate::void,
         outlen: i32,
     ) -> i32;
     pub fn sceIoIoctl(
         fd: SceUID,
         cmd: u32,
-        indata: *mut ::void,
+        indata: *mut crate::void,
         inlen: i32,
-        outdata: *mut ::void,
+        outdata: *mut crate::void,
         outlen: i32,
     ) -> i32;
     pub fn sceIoIoctlAsync(
         fd: SceUID,
         cmd: u32,
-        indata: *mut ::void,
+        indata: *mut crate::void,
         inlen: i32,
-        outdata: *mut ::void,
+        outdata: *mut crate::void,
         outlen: i32,
     ) -> i32;
 }

--- a/src/io/dirent.rs
+++ b/src/io/dirent.rs
@@ -1,4 +1,4 @@
-use types::SceUID;
+use crate::types::SceUID;
 
 use super::stat::SceIoStat;
 
@@ -6,7 +6,7 @@ use super::stat::SceIoStat;
 pub struct SceIoDirent {
     pub d_stat: SceIoStat,
     pub d_name: [u8; 256],
-    pub d_private: *mut ::void,
+    pub d_private: *mut crate::void,
     pub dummy: i32,
 }
 

--- a/src/io/fcntl.rs
+++ b/src/io/fcntl.rs
@@ -1,6 +1,6 @@
-use types::SceOff;
-use types::SceSize;
-use types::SceUID;
+use crate::types::SceOff;
+use crate::types::SceSize;
+use crate::types::SceUID;
 
 #[repr(i32)]
 pub enum SceIoMode {
@@ -50,12 +50,12 @@ extern "C" {
     pub fn sceIoOpenAsync(file: *const u8, flags: i32, mode: SceIoMode) -> SceUID;
     pub fn sceIoClose(fd: SceUID) -> i32;
     pub fn sceIoCloseAsync(fd: SceUID) -> i32;
-    pub fn sceIoRead(fd: SceUID, data: *mut ::void, size: SceSize) -> i32;
-    pub fn sceIoReadAsync(fd: SceUID, data: *mut ::void, size: SceSize) -> i32;
-    pub fn sceIoPread(fd: SceUID, data: *mut ::void, size: SceSize, offset: SceOff) -> i32;
-    pub fn sceIoWrite(fd: SceUID, data: *const ::void, size: SceSize) -> i32;
-    pub fn sceIoWriteAsync(fd: SceUID, data: *const ::void, size: SceSize) -> i32;
-    pub fn sceIoPwrite(fd: SceUID, data: *const ::void, size: SceSize, offset: SceOff) -> i32;
+    pub fn sceIoRead(fd: SceUID, data: *mut crate::void, size: SceSize) -> i32;
+    pub fn sceIoReadAsync(fd: SceUID, data: *mut crate::void, size: SceSize) -> i32;
+    pub fn sceIoPread(fd: SceUID, data: *mut crate::void, size: SceSize, offset: SceOff) -> i32;
+    pub fn sceIoWrite(fd: SceUID, data: *const crate::void, size: SceSize) -> i32;
+    pub fn sceIoWriteAsync(fd: SceUID, data: *const crate::void, size: SceSize) -> i32;
+    pub fn sceIoPwrite(fd: SceUID, data: *const crate::void, size: SceSize, offset: SceOff) -> i32;
     pub fn sceIoLseek(fd: SceUID, offset: SceOff, whence: SceIoSeekMode) -> SceOff;
     pub fn sceIoLseekAsync(fd: SceUID, offset: SceOff, whence: SceIoSeekMode) -> SceOff;
     pub fn sceIoLseek32(fd: SceUID, offset: i32, whence: SceIoSeekMode) -> SceOff;

--- a/src/io/stat.rs
+++ b/src/io/stat.rs
@@ -1,7 +1,7 @@
-use types::SceDateTime;
-use types::SceMode;
-use types::SceOff;
-use types::SceUID;
+use crate::types::SceDateTime;
+use crate::types::SceMode;
+use crate::types::SceOff;
+use crate::types::SceUID;
 
 #[repr(i32)]
 pub enum SceIoAccessMode {

--- a/src/kernel/clib.rs
+++ b/src/kernel/clib.rs
@@ -1,4 +1,4 @@
-use types::SceSize;
+use crate::types::SceSize;
 
 #[cfg_attr(
     not(feature = "dox"),
@@ -9,7 +9,7 @@ extern "C" {
     pub type va_list;
 
     pub fn sceClibStrcmp(s1: *const u8, s2: *const u8) -> i32;
-    pub fn sceClibStrncmp(s1: *const u8, s2: *const u8, n: SceSize) -> *mut ::void;
+    pub fn sceClibStrncmp(s1: *const u8, s2: *const u8, n: SceSize) -> *mut crate::void;
     pub fn sceClibStrncasecmp(s1: *const u8, s2: *const u8) -> i32;
     pub fn sceClibStrncpy(dest: *mut u8, src: *const u8, n: SceSize) -> *mut u8;
     pub fn sceClibStrncat(dest: *mut u8, src: *const u8, n: SceSize) -> *mut u8;
@@ -20,7 +20,7 @@ extern "C" {
     pub fn sceClibSnprintf(s: *mut u8, size: SceSize, format: *const u8, ...) -> i32;
     pub fn sceClibVsnprintf(s: *mut u8, size: SceSize, format: *const u8, ap: va_list) -> i32;
 
-    pub fn sceClibMemset(s: *mut ::void, c: i32, n: SceSize) -> *mut ::void;
-    pub fn sceClibMemcpy(dest: *mut ::void, src: *const ::void, n: SceSize) -> *mut ::void;
-    pub fn sceClibMemmove(dest: *mut ::void, src: *const ::void, n: SceSize) -> *mut ::void;
+    pub fn sceClibMemset(s: *mut crate::void, c: i32, n: SceSize) -> *mut crate::void;
+    pub fn sceClibMemcpy(dest: *mut crate::void, src: *const crate::void, n: SceSize) -> *mut crate::void;
+    pub fn sceClibMemmove(dest: *mut crate::void, src: *const crate::void, n: SceSize) -> *mut crate::void;
 }

--- a/src/kernel/rng.rs
+++ b/src/kernel/rng.rs
@@ -3,5 +3,5 @@
     link(kind = "static", name = "SceLibKernel_stub")
 )]
 extern "C" {
-    pub fn sceKernelGetRandomNumber(output: *mut ::void, size: u32);
+    pub fn sceKernelGetRandomNumber(output: *mut crate::void, size: u32);
 }

--- a/src/kernel/sysmem.rs
+++ b/src/kernel/sysmem.rs
@@ -1,6 +1,6 @@
-use types::SceSize;
-use types::SceUID;
-use types::SceUInt32;
+use crate::types::SceSize;
+use crate::types::SceUID;
+use crate::types::SceUInt32;
 
 #[repr(i32)]
 pub enum SceKernelMemBlockType {
@@ -43,7 +43,7 @@ pub enum SceKernelModel {
 #[repr(C)]
 pub struct SceKernelMemBlockInfo {
     pub size: SceSize,
-    pub mappedBase: *mut ::void,
+    pub mappedBase: *mut crate::void,
     pub mappedSize: SceSize,
     pub memory_type: SceKernelMemoryType,
     pub access: SceUInt32,
@@ -75,19 +75,19 @@ extern "C" {
         optp: *mut SceKernelAllocMemBlockOpt,
     ) -> SceUID;
     pub fn sceKernelFreeMemBlock(uid: SceUID) -> i32;
-    pub fn sceKernelGetMemBlockBase(uid: SceUID, basep: *mut *mut ::void) -> i32;
-    pub fn sceKernelFindMemBlockByAddr(addr: *const ::void, size: SceSize) -> SceUID;
+    pub fn sceKernelGetMemBlockBase(uid: SceUID, basep: *mut *mut crate::void) -> i32;
+    pub fn sceKernelFindMemBlockByAddr(addr: *const crate::void, size: SceSize) -> SceUID;
     pub fn sceKernelGetMemBlockInfoByAddr(
-        base: *mut ::void,
+        base: *mut crate::void,
         info: *mut SceKernelMemBlockInfo,
     ) -> i32;
     pub fn sceKernelGetMemBlockInfoByRange(
-        base: *mut ::void,
+        base: *mut crate::void,
         size: SceSize,
         info: *mut SceKernelMemBlockInfo,
     ) -> i32;
     pub fn sceKernelAllocMemBlockForVM(name: *const u8, size: SceSize) -> SceUID;
-    pub fn sceKernelSyncVMDomain(uid: SceUID, data: *const ::void, size: SceSize) -> i32;
+    pub fn sceKernelSyncVMDomain(uid: SceUID, data: *const crate::void, size: SceSize) -> i32;
     pub fn sceKernelOpenVMDomain() -> i32;
     pub fn sceKernelCloseVMDomain() -> i32;
     pub fn sceKernelOpenMemBlock(name: *const u8, flags: i32) -> i32;

--- a/src/kernel/threadmgr.rs
+++ b/src/kernel/threadmgr.rs
@@ -1,8 +1,8 @@
-use types::SceSize;
-use types::SceUID;
-use types::SceUInt;
-use types::SceUInt32;
-use types::SceUInt64;
+use crate::types::SceSize;
+use crate::types::SceUID;
+use crate::types::SceUInt;
+use crate::types::SceUInt32;
+use crate::types::SceUInt64;
 
 type SceKernelSysClock = SceUInt64;
 
@@ -33,7 +33,7 @@ pub enum SceKernelMutexAttribute {
 
 // Threads
 
-type SceKernelThreadEntry = extern "C" fn(SceSize, *mut ::void) -> i32;
+type SceKernelThreadEntry = extern "C" fn(SceSize, *mut crate::void) -> i32;
 
 #[repr(C)]
 pub struct SceKernelThreadOptParam {
@@ -49,7 +49,7 @@ pub struct SceKernelThreadInfo {
     pub attr: SceUInt,
     pub status: i32,
     pub entry: SceKernelThreadEntry,
-    pub stack: *mut ::void,
+    pub stack: *mut crate::void,
     pub stackSize: i32,
     pub initPriority: i32,
     pub currentPriority: i32,
@@ -146,7 +146,7 @@ extern "C" {
         option: *const SceKernelThreadOptParam,
     ) -> SceUID;
     pub fn sceKernelDeleteThread(thid: SceUID) -> i32;
-    pub fn sceKernelStartThread(thid: SceUID, arglen: SceSize, argp: *mut ::void) -> i32;
+    pub fn sceKernelStartThread(thid: SceUID, arglen: SceSize, argp: *mut crate::void) -> i32;
     pub fn sceKernelWaitThreadEnd(thid: SceUID, stat: *mut i32, timeout: *mut SceUInt) -> i32;
     pub fn sceKernelWaitThreadEndCB(thid: SceUID, stat: *mut i32, timeout: *mut SceUInt) -> i32;
     pub fn sceKernelDelayThread(delay: SceUInt) -> i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(untagged_unions)]
 #![feature(extern_types)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/system_param.rs
+++ b/src/system_param.rs
@@ -1,4 +1,4 @@
-#[repr(C)]
+#[repr(u32)]
 pub enum SceSystemParamId {
     /// Language settings
     SCE_SYSTEM_PARAM_ID_LANG = 1,
@@ -18,7 +18,7 @@ pub enum SceSystemParamId {
     SCE_SYSTEM_PARAM_ID_MAX_VALUE = 0xFFFFFFFF,
 }
 
-#[repr(C)]
+#[repr(u32)]
 pub enum SceSystemParamLang {
     /// Japanese
     SCE_SYSTEM_PARAM_LANG_JAPANESE,
@@ -64,7 +64,7 @@ pub enum SceSystemParamLang {
     SCE_SYSTEM_PARAM_LANG_MAX_VALUE = 0xFFFFFFFF,
 }
 
-#[repr(C)]
+#[repr(u32)]
 pub enum SceSystemParamEnterButtonAssign {
     SCE_SYSTEM_PARAM_ENTER_BUTTON_CIRCLE,
     SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS,

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,8 +44,8 @@ pub type SceByte8 = u8;
 pub type SceWChar16 = u16;
 pub type SceWChar32 = u32;
 
-pub type SceVoid = ::void;
-pub type ScePVoid = *mut ::void;
+pub type SceVoid = crate::void;
+pub type ScePVoid = *mut crate::void;
 
 pub type SceIntPtr = i32;
 pub type SceUIntPtr = u32;
@@ -202,7 +202,7 @@ pub union SceUnion32 {
     uc: [u8; 4],
     c: [i8; 4],
     f: f32,
-    p: *mut ::void,
+    p: *mut crate::void,
 }
 
 #[derive(Copy, Clone)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,7 @@ pub type SceULong64 = u64;
 pub type SceSize = u32;
 pub type SceSSize = i32;
 
+#[derive(Copy, Clone, Debug)]
 #[repr(i32)]
 pub enum SceBool {
     SCE_FALSE = 0,
@@ -50,18 +51,21 @@ pub type SceIntPtr = i32;
 pub type SceUIntPtr = u32;
 pub type SceUIntVAddr = SceUIntPtr;
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceIVector2 {
     x: SceInt,
     y: SceInt,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFVector2 {
     x: SceFloat,
     y: SceFloat,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceIVector3 {
     x: SceInt,
@@ -69,6 +73,7 @@ pub struct SceIVector3 {
     z: SceInt,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFVector3 {
     x: SceFloat,
@@ -76,6 +81,7 @@ pub struct SceFVector3 {
     z: SceFloat,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceIVector4 {
     x: SceInt,
@@ -84,6 +90,7 @@ pub struct SceIVector4 {
     w: SceInt,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceUVector4 {
     x: SceUInt,
@@ -92,6 +99,7 @@ pub struct SceUVector4 {
     w: SceUInt,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFVector4 {
     x: SceFloat,
@@ -100,18 +108,21 @@ pub struct SceFVector4 {
     w: SceFloat,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceIMatrix2 {
     x: SceIVector2,
     y: SceIVector2,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFMatrix2 {
     x: SceFVector2,
     y: SceFVector2,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceIMatrix3 {
     x: SceIVector3,
@@ -119,6 +130,7 @@ pub struct SceIMatrix3 {
     z: SceIVector3,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFMatrix3 {
     x: SceFVector3,
@@ -126,6 +138,7 @@ pub struct SceFMatrix3 {
     z: SceFVector3,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceIMatrix4 {
     x: SceIVector4,
@@ -134,6 +147,7 @@ pub struct SceIMatrix4 {
     w: SceIVector4,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceUMatrix4 {
     x: SceUVector4,
@@ -142,6 +156,7 @@ pub struct SceUMatrix4 {
     w: SceUVector4,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFMatrix4 {
     x: SceFVector4,
@@ -150,6 +165,7 @@ pub struct SceFMatrix4 {
     w: SceFVector4,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFQuaternion {
     x: SceFloat,
@@ -158,6 +174,7 @@ pub struct SceFQuaternion {
     w: SceFloat,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFColor {
     r: SceFloat,
@@ -166,6 +183,7 @@ pub struct SceFColor {
     a: SceFloat,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceFPlane {
     a: SceFloat,
@@ -174,6 +192,7 @@ pub struct SceFPlane {
     d: SceFloat,
 }
 
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union SceUnion32 {
     ui: u32,
@@ -186,6 +205,7 @@ pub union SceUnion32 {
     p: *mut ::void,
 }
 
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union SceUnion64 {
     ull: SceULong64,
@@ -201,6 +221,7 @@ pub union SceUnion64 {
     iv: SceIVector2,
 }
 
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union SceUnion128 {
     ull: [SceULong64; 2],
@@ -219,6 +240,7 @@ pub union SceUnion128 {
     iv: SceIVector4,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SceDateTime {
     year: u16,


### PR DESCRIPTION
Hey, thanks for this crate!

The crate wasn't compiling for me, so I've took the opportunity to fix the warnings. Note that after all those changes, the VPK size is still the same.

I made 4 commits:

1. Fix compilation errors in recent versions of rust, introduced by https://github.com/rust-lang/rust/pull/55632, the code was using repr(C) in enums which used values higher than isize::MAX (same as i32::MAX on vita), which is considered an overflow. Since C enums have no signedness guarantee, I only changed to repr(u32) those that would actually overflow.
2. I've fixed all warnings in the repository
3. I've derived `Copy` and `Clone` for `Sce` types, since they can be copied, are small and its how they're usually used in C. While at it, also derived `Debug`. I've removed `#![feature(untagged_unions)]` since its no longer needed.
4. I've migrated the crates the code to the Rust 2018 edition by following the [Edition Guide](https://doc.rust-lang.org/nightly/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html). If you'd rather maintain the crate in the 2015 edition, I'll just remove this commit.

I also needed to update to patch `rust-script` as it wasn't detecting the `fn main()` in some `cargo-make` scripts: https://github.com/fornwall/rust-script/pull/18

What do you think?